### PR TITLE
Fix FM demodulation

### DIFF
--- a/src/dsp/demodulators.ts
+++ b/src/dsp/demodulators.ts
@@ -133,15 +133,14 @@ export class FMDemodulator {
         div = real / imag;
         sgn = -sgn;
       }
-      const value =
+      const angle =
         circ +
         sgn *
           (ang +
             div /
               (0.98419158358617365 +
-                div * (0.093485702629671305 + div * 0.19556307900617517))) *
-          mul;
-      out[i] = value;
+                div * (0.093485702629671305 + div * 0.19556307900617517)));
+      out[i] = angle * mul;
     }
     this.lI = lI;
     this.lQ = lQ;


### PR DESCRIPTION
The whole angle from the atan2 output needs to be multiplied by `mul`, but in the original code, the `circ` part was not included in the multiplication.

It causes some distortion of the output signal, which I didn't notice auditively, but which causes my [RDS decoder](https://github.com/ChristopheJacquet/RdsSurveyor2/) to fail (to a varying degree depending on the stations).