### PR TITLE
fix: add .js extension to all imports and exports

### DIFF
--- a/examples/highlevel/script.js
+++ b/examples/highlevel/script.js
@@ -1,11 +1,11 @@
-import { Demodulator } from "@jtarrio/webrtlsdr/demod/demodulator";
+import { Demodulator } from "@jtarrio/webrtlsdr/demod/demodulator.js";
 import {
   getMode,
   getSchemes,
   modeParameters,
-} from "@jtarrio/webrtlsdr/demod/modes";
-import { Radio } from "@jtarrio/webrtlsdr/radio";
-import { DirectSampling, RTL2832U_Provider } from "@jtarrio/webrtlsdr/rtlsdr";
+} from "@jtarrio/webrtlsdr/demod/modes.js";
+import { Radio } from "@jtarrio/webrtlsdr/radio.js";
+import { DirectSampling, RTL2832U_Provider } from "@jtarrio/webrtlsdr/rtlsdr.js";
 
 var elements = {};
 var demodulator;

--- a/examples/lowlevel/script.js
+++ b/examples/lowlevel/script.js
@@ -1,4 +1,4 @@
-import { RTL2832U_Provider } from "@jtarrio/webrtlsdr/rtlsdr";
+import { RTL2832U_Provider } from "@jtarrio/webrtlsdr/rtlsdr.js";
 
 var elements = {};
 var provider;

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "version": "2.0.1",
   "author": "Jacobo Tarrio <jtarrio@gmail.com>",
   "license": "Apache-2.0",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jtarrio/webrtlsdr.git"
   },
   "exports": {
-    "./*": "./dist/*.js"
+    "./*": "./dist/*"
   },
   "files": ["./dist"],
   "scripts": {

--- a/src/demod/demod-am.ts
+++ b/src/demod/demod-am.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { makeLowPassKernel } from "../dsp/coefficients";
-import { AMDemodulator } from "../dsp/demodulators";
-import { FrequencyShifter, FIRFilter } from "../dsp/filters";
-import { getPower } from "../dsp/power";
-import { ComplexDownsampler } from "../dsp/resamplers";
-import { Configurator, Demod, Demodulated } from "./modes";
+import { makeLowPassKernel } from "../dsp/coefficients.js";
+import { AMDemodulator } from "../dsp/demodulators.js";
+import { FrequencyShifter, FIRFilter } from "../dsp/filters.js";
+import { getPower } from "../dsp/power.js";
+import { ComplexDownsampler } from "../dsp/resamplers.js";
+import { Configurator, Demod, Demodulated } from "./modes.js";
 
 /** Mode parameters for AM. */
 export type ModeAM = { scheme: "AM"; bandwidth: number; squelch: number };

--- a/src/demod/demod-cw.ts
+++ b/src/demod/demod-cw.ts
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { makeLowPassKernel } from "../dsp/coefficients";
-import { AGC, FIRFilter, FrequencyShifter } from "../dsp/filters";
-import { getPower } from "../dsp/power";
-import { ComplexDownsampler } from "../dsp/resamplers";
-import { Configurator, Demod, Demodulated } from "./modes";
+import { makeLowPassKernel } from "../dsp/coefficients.js";
+import { AGC, FIRFilter, FrequencyShifter } from "../dsp/filters.js";
+import { getPower } from "../dsp/power.js";
+import { ComplexDownsampler } from "../dsp/resamplers.js";
+import { Configurator, Demod, Demodulated } from "./modes.js";
 
 /** Mode parameters for CW. */
 export type ModeCW = { scheme: "CW"; bandwidth: number };

--- a/src/demod/demod-nbfm.ts
+++ b/src/demod/demod-nbfm.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { makeLowPassKernel } from "../dsp/coefficients";
-import { FMDemodulator } from "../dsp/demodulators";
-import { FIRFilter, FrequencyShifter } from "../dsp/filters";
-import { getPower } from "../dsp/power";
-import { ComplexDownsampler } from "../dsp/resamplers";
-import { Configurator, Demod, Demodulated } from "./modes";
+import { makeLowPassKernel } from "../dsp/coefficients.js";
+import { FMDemodulator } from "../dsp/demodulators.js";
+import { FIRFilter, FrequencyShifter } from "../dsp/filters.js";
+import { getPower } from "../dsp/power.js";
+import { ComplexDownsampler } from "../dsp/resamplers.js";
+import { Configurator, Demod, Demodulated } from "./modes.js";
 
 /** Mode parameters for NBFM. */
 export type ModeNBFM = { scheme: "NBFM"; maxF: number; squelch: number };

--- a/src/demod/demod-ssb.ts
+++ b/src/demod/demod-ssb.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { makeLowPassKernel } from "../dsp/coefficients";
-import { Sideband, SSBDemodulator } from "../dsp/demodulators";
-import { FrequencyShifter, AGC, FIRFilter } from "../dsp/filters";
-import { getPower } from "../dsp/power";
-import { ComplexDownsampler } from "../dsp/resamplers";
-import { Configurator, Demod, Demodulated } from "./modes";
+import { makeLowPassKernel } from "../dsp/coefficients.js";
+import { Sideband, SSBDemodulator } from "../dsp/demodulators.js";
+import { FrequencyShifter, AGC, FIRFilter } from "../dsp/filters.js";
+import { getPower } from "../dsp/power.js";
+import { ComplexDownsampler } from "../dsp/resamplers.js";
+import { Configurator, Demod, Demodulated } from "./modes.js";
 
 /** Mode parameters for SSB. */
 export type ModeSSB = {

--- a/src/demod/demod-wbfm.ts
+++ b/src/demod/demod-wbfm.ts
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { makeLowPassKernel } from "../dsp/coefficients";
-import { FMDemodulator, StereoSeparator } from "../dsp/demodulators";
-import { FrequencyShifter, Deemphasizer, FIRFilter } from "../dsp/filters";
-import { getPower } from "../dsp/power";
-import { ComplexDownsampler, RealDownsampler } from "../dsp/resamplers";
-import { Configurator, Demod, Demodulated } from "./modes";
+import { makeLowPassKernel } from "../dsp/coefficients.js";
+import { FMDemodulator, StereoSeparator } from "../dsp/demodulators.js";
+import { FrequencyShifter, Deemphasizer, FIRFilter } from "../dsp/filters.js";
+import { getPower } from "../dsp/power.js";
+import { ComplexDownsampler, RealDownsampler } from "../dsp/resamplers.js";
+import { Configurator, Demod, Demodulated } from "./modes.js";
 
 /** Mode parameters for WBFM. */
 export type ModeWBFM = { scheme: "WBFM"; stereo: boolean };

--- a/src/demod/demodulator.ts
+++ b/src/demod/demodulator.ts
@@ -14,13 +14,13 @@
 
 /** Exports the `Demodulator` class with all the demodulation schemes already registered. */
 
-export * from "./empty-demodulator";
-import { registerDemod } from "./modes";
-import { ConfigAM, DemodAM } from "./demod-am";
-import { ConfigCW, DemodCW } from "./demod-cw";
-import { ConfigNBFM, DemodNBFM } from "./demod-nbfm";
-import { ConfigSSB, DemodSSB } from "./demod-ssb";
-import { ConfigWBFM, DemodWBFM } from "./demod-wbfm";
+export * from "./empty-demodulator.js";
+import { registerDemod } from "./modes.js";
+import { ConfigAM, DemodAM } from "./demod-am.js";
+import { ConfigCW, DemodCW } from "./demod-cw.js";
+import { ConfigNBFM, DemodNBFM } from "./demod-nbfm.js";
+import { ConfigSSB, DemodSSB } from "./demod-ssb.js";
+import { ConfigWBFM, DemodWBFM } from "./demod-wbfm.js";
 
 registerDemod("WBFM", DemodWBFM, ConfigWBFM);
 registerDemod("NBFM", DemodNBFM, ConfigNBFM);

--- a/src/demod/empty-demodulator.ts
+++ b/src/demod/empty-demodulator.ts
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Demod, Mode, getDemod, getMode, modeParameters } from "./modes";
-import { Player } from "./player";
-import { AudioPlayer } from "../players/audioplayer";
-import { SampleReceiver } from "../radio";
+import { Demod, Mode, getDemod, getMode, modeParameters } from "./modes.js";
+import { Player } from "./player.js";
+import { AudioPlayer } from "../players/audioplayer.js";
+import { SampleReceiver } from "../radio.js";
 
 /**
  * A class that takes a stream of radio samples and demodulates

--- a/src/demod/sample-counter.ts
+++ b/src/demod/sample-counter.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { SampleReceiver } from "../radio";
+import { SampleReceiver } from "../radio.js";
 
 /** A SampleReceiver that counts received samples to send a `sample-click` event periodically. */
 export class SampleCounter extends EventTarget implements SampleReceiver {

--- a/src/demod/spectrum.ts
+++ b/src/demod/spectrum.ts
@@ -14,10 +14,10 @@
 
 // Continuous spectrum analyzer.
 
-import { Float32RingBuffer } from "../dsp/buffers";
-import { makeBlackmanWindow } from "../dsp/coefficients";
-import { FFT } from "../dsp/fft";
-import { SampleReceiver } from "../radio";
+import { Float32RingBuffer } from "../dsp/buffers.js";
+import { makeBlackmanWindow } from "../dsp/coefficients.js";
+import { FFT } from "../dsp/fft.js";
+import { SampleReceiver } from "../radio.js";
 
 /** A sample receiver that computes the received signal's spectrum. */
 export class Spectrum implements SampleReceiver {

--- a/src/dsp/converters.ts
+++ b/src/dsp/converters.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { IqBuffer } from "./buffers";
+import { IqBuffer } from "./buffers.js";
 
 /**
  * Converts the given buffer of unsigned 8-bit samples into a pair of

--- a/src/dsp/demodulators.ts
+++ b/src/dsp/demodulators.ts
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { makeHilbertKernel } from "./coefficients";
-import { FIRFilter } from "./filters";
-import { Float32Buffer } from "./buffers";
+import { makeHilbertKernel } from "./coefficients.js";
+import { FIRFilter } from "./filters.js";
+import { Float32Buffer } from "./buffers.js";
 
 /** The sideband to demodulate. */
 export enum Sideband {

--- a/src/dsp/fft.ts
+++ b/src/dsp/fft.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Float32RingBuffer, IqBuffer } from "./buffers";
+import { Float32RingBuffer, IqBuffer } from "./buffers.js";
 
 /** Fast Fourier Transform implementation. */
 

--- a/src/dsp/resamplers.ts
+++ b/src/dsp/resamplers.ts
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Float32Buffer } from "./buffers";
-import { makeLowPassKernel } from "./coefficients";
-import { FIRFilter } from "./filters";
+import { Float32Buffer } from "./buffers.js";
+import { makeLowPassKernel } from "./coefficients.js";
+import { FIRFilter } from "./filters.js";
 
 /** A class to convert the input to a lower sample rate. */
 class Downsampler {

--- a/src/players/audioplayer.ts
+++ b/src/players/audioplayer.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Player } from "../demod/player";
+import { Player } from "../demod/player.js";
 
 /** A class to play a series of sample buffers at a constant rate using the Web Audio API. */
 export class AudioPlayer implements Player {

--- a/src/radio.ts
+++ b/src/radio.ts
@@ -1,2 +1,2 @@
-export * from "./radio/radio";
-export * from "./radio/sample_receiver";
+export * from "./radio/radio.js";
+export * from "./radio/sample_receiver.js";

--- a/src/radio/radio.ts
+++ b/src/radio/radio.ts
@@ -14,11 +14,11 @@
 
 /** State machine to orchestrate the RTL2832, demodulation, and audio playing. */
 
-import { U8ToFloat32 } from "../dsp/converters";
-import { RadioError, RadioErrorType } from "../errors";
-import { DirectSampling, RtlDevice, RtlDeviceProvider } from "../rtlsdr/rtldevice";
-import { Channel } from "./msgqueue";
-import { SampleReceiver } from "./sample_receiver";
+import { U8ToFloat32 } from "../dsp/converters.js";
+import { RadioError, RadioErrorType } from "../errors.js";
+import { DirectSampling, RtlDevice, RtlDeviceProvider } from "../rtlsdr/rtldevice.js";
+import { Channel } from "./msgqueue.js";
+import { SampleReceiver } from "./sample_receiver.js";
 
 /** A message sent to the state machine. */
 type Message =

--- a/src/rtlsdr.ts
+++ b/src/rtlsdr.ts
@@ -1,2 +1,2 @@
-export * from './rtlsdr/rtldevice';
-export * from './rtlsdr/rtl2832u';
+export * from './rtlsdr/rtldevice.js';
+export * from './rtlsdr/rtl2832u.js';

--- a/src/rtlsdr/r820t.ts
+++ b/src/rtlsdr/r820t.ts
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { R8xx, STD_MUX_CFGS } from "./r8xx";
-import { RtlCom } from "./rtlcom";
-import { Tuner } from "./tuner";
+import { R8xx, STD_MUX_CFGS } from "./r8xx.js";
+import { RtlCom } from "./rtlcom.js";
+import { Tuner } from "./tuner.js";
 
 /** Operations on the R820T tuner chip. */
 export class R820T extends R8xx implements Tuner {

--- a/src/rtlsdr/r828d.ts
+++ b/src/rtlsdr/r828d.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { R8xx, STD_MUX_CFGS } from "./r8xx";
-import { RtlCom } from "./rtlcom";
-import { Tuner } from "./tuner";
+import { R8xx, STD_MUX_CFGS } from "./r8xx.js";
+import { RtlCom } from "./rtlcom.js";
+import { Tuner } from "./tuner.js";
 
 /** Operations on the R828D tuner chip. */
 export class R828D extends R8xx implements Tuner {

--- a/src/rtlsdr/r8xx.ts
+++ b/src/rtlsdr/r8xx.ts
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { RadioError, RadioErrorType } from "../errors";
-import { RtlCom } from "./rtlcom";
-import { Tuner } from "./tuner";
+import { RadioError, RadioErrorType } from "../errors.js";
+import { RtlCom } from "./rtlcom.js";
+import { Tuner } from "./tuner.js";
 
 /** Standard configurations for the multiplexer in different frequency bands. */
 export const STD_MUX_CFGS: [number, number, number, number][] = [

--- a/src/rtlsdr/rtl2832u.ts
+++ b/src/rtlsdr/rtl2832u.ts
@@ -13,17 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { RadioError, RadioErrorType } from "../errors";
-import { R820T } from "./r820t";
-import { R828D } from "./r828d";
-import { RtlCom } from "./rtlcom";
+import { RadioError, RadioErrorType } from "../errors.js";
+import { R820T } from "./r820t.js";
+import { R828D } from "./r828d.js";
+import { RtlCom } from "./rtlcom.js";
 import {
   DirectSampling,
   RtlDevice,
   RtlDeviceProvider,
   SampleBlock,
-} from "./rtldevice";
-import { Tuner } from "./tuner";
+} from "./rtldevice.js";
+import { Tuner } from "./tuner.js";
 
 /** Known RTL2832 devices. */
 const TUNERS = [

--- a/src/rtlsdr/rtlcom.ts
+++ b/src/rtlsdr/rtlcom.ts
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { RadioError, RadioErrorType } from "../errors";
+import { RadioError, RadioErrorType } from "../errors.js";
 
 /** Low-level communications with the RTL2832U-base dongle. */
 export class RtlCom {


### PR DESCRIPTION
These changes makes the library more compliant and allows to use it within Node.js, e.g. adapted from your example

```js
import { Demodulator } from "@jtarrio/webrtlsdr/demod/demodulator.js";
import {
  getMode,
  getSchemes,
  modeParameters,
} from "@jtarrio/webrtlsdr/demod/modes.js";
import { Radio } from "@jtarrio/webrtlsdr/radio.js";
import { DirectSampling, RTL2832U_Provider } from "@jtarrio/webrtlsdr/rtlsdr.js";

import { AudioContext } from 'isomorphic-web-audio-api';
import { webusb } from "usb";
globalThis.AudioContext = AudioContext;
globalThis.navigator.usb = webusb;

try {
    const demodulator = new Demodulator();
    const radio = new Radio(new RTL2832U_Provider(), demodulator);

    radio.setFrequency(144000000);
    radio.setDirectSamplingMethod(DirectSampling.Off);
    radio.setFrequencyCorrection(0);
    radio.setGain(100);
    demodulator.setFrequencyOffset(0);
    demodulator.setVolume(1);
    demodulator.setMode(getMode("WBFM"));

    radio.start();
    radio.addEventListener('directSampling', (e) => console.log('directSampling', e));

    globalThis.demodulator = demodulator;
    globalThis.radio = radio;
} catch (err) {
    console.log(err);
}

setInterval(() => {}, 1000);
```